### PR TITLE
Configure lifecycle processor to use async executor

### DIFF
--- a/src/main/java/com/example/config/AppConfig.java
+++ b/src/main/java/com/example/config/AppConfig.java
@@ -1,14 +1,31 @@
 package com.example.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.DefaultLifecycleProcessor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 
 @ComponentScan(basePackages = {"com.example.service"})
 @PropertySource("classpath:application.properties")
 @Configuration
 @Import({RedisConfig.class, WorkflowConfig.class})
 public class AppConfig {
-    
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        return new SimpleAsyncTaskExecutor("lifecycle-");
+    }
+
+    @Bean(name = "lifecycleProcessor")
+    public DefaultLifecycleProcessor lifecycleProcessor(TaskExecutor taskExecutor) {
+        DefaultLifecycleProcessor processor = new DefaultLifecycleProcessor();
+        processor.setTaskExecutor(taskExecutor);
+        // Set a default shutdown timeout of 30 seconds
+        processor.setTimeoutPerShutdownPhase(30_000);
+        return processor;
+    }
 }


### PR DESCRIPTION
## Summary
- configure `AppConfig` with a `TaskExecutor`
- provide a `DefaultLifecycleProcessor` bean that uses that executor

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a81915248322be0fe52281ba5816